### PR TITLE
Sorted case where user can exit or continue the game at the end

### DIFF
--- a/Zombies Survival/Program.cs
+++ b/Zombies Survival/Program.cs
@@ -15,10 +15,10 @@ namespace Skeleton_Program
     internal class Program
     {
         static char choice;
+        //Boolean to control exiting the game after finishing
+        static bool exit;
         static void Main()
-        {
-
-
+        {           
             int tasks = 0;
             do
             {
@@ -72,12 +72,12 @@ namespace Skeleton_Program
                         break;
                     case 4:
                         task4();
-                        break;
+                        break;                  
                     case 5:
                         Console.WriteLine("Exiting ...");
                         break;
                 }
-            } while (tasks >= 1 && tasks <= 4);
+            } while ((tasks >= 1 && tasks <= 4) && !exit);
             //Loop breaks when user enters 1          
         }
 
@@ -942,10 +942,6 @@ namespace Skeleton_Program
             Console.WriteLine("You walk into the hallway.");
         }
 
-
-
-
-
         static void courtyard(List<string> inventory)
         {
             Random Rand = new Random();
@@ -1564,9 +1560,35 @@ namespace Skeleton_Program
         }
         static void Exit()
         {
+            
             //add the ending
             Console.WriteLine("the end");
-            Console.ReadLine();
+            do {
+                try
+                {
+                    Console.WriteLine("Do you want to play again (y/n)");
+                    choice = Convert.ToChar(Console.ReadLine().ToLower());
+                    if (choice != 'y' && choice != 'n')
+                        Console.WriteLine("Invalid choice");
+
+                }
+                catch (FormatException)
+                {
+
+                    Console.WriteLine("Invalid format");
+                }
+            }while (choice!='y' && choice!= 'n');
+            switch (choice)
+            {
+                case 'y':  
+                    //Returns back to the menu
+                    break;
+                case 'n':
+                    exit = true;
+                    break;
+            }
+
+            
         }
 
     }


### PR DESCRIPTION
Created a public bool called "exit" that is initially set to false at the beginning of the game.
And when the user reaches the end of the game, when they want to play the game again they will be looped to the start of the game. This mean's that the boolean "exit" is still set to false. But when the user want's to exit the game, the boolean is set to true, and therefore the main do while loop: do { } while ((tasks >= 1 && tasks <= 4) && !exit) will break.
